### PR TITLE
Move odin.dust from Imports to Suggests & add odin

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,14 +21,15 @@ License: Apache-2.0 license
 Encoding: UTF-8
 LazyData: true
 LinkingTo:
-  cpp11 (>= 0.5.2),
-  dust (>= 0.15.3) 
+    cpp11 (>= 0.5.2),
+    dust (>= 0.15.3)
 Imports: 
-  dust (>= 0.15.3),
-  odin.dust (>= 0.3.13),
-  mcstate (>= 0.9.22)
+    dust (>= 0.15.3),
+    mcstate (>= 0.9.22)
 RoxygenNote: 7.3.3
 Suggests: 
     knitr,
-    rmarkdown
+    rmarkdown,
+    odin (>= 1.5.12),
+    odin.dust (>= 0.3.13)
 VignetteBuilder: knitr

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ This is an R package to simulate and fit a population genetic model with paramet
 
 ## Installation
 
-Install Stubentiger's dependencies, `odin.dust`, `dust`, and `mcstate`:
+Install Stubentiger's dependencies, `dust`, and `mcstate`:
 ```R
 install.packages(
-  "odin.dust", "dust", "mcstate",
+  "dust", "mcstate",
   repos = c("https://mrc-ide.r-universe.dev", "https://cloud.r-project.org"))
 ```
 


### PR DESCRIPTION
odin.dust isn't needed to compile & run the pregenerated dust model that comes with the package. Moved it (and added odin) to suggests in case someone wants to modify the odin code